### PR TITLE
Fix DM handler: respond based on membership, not a single DM channel

### DIFF
--- a/server/events/message-create/index.ts
+++ b/server/events/message-create/index.ts
@@ -22,7 +22,9 @@ export async function execute(
   const thread_id = payload.message.thread_id ?? null;
 
   const isDM = channel.chatable_type === 'DirectMessage';
-  const myDMId = botUser.custom_fields?.last_chat_channel_id;
+  const isMember = Boolean(channel.current_user_membership);
+  // Note: In some environments, 'current_user_membership' may be missing.
+  // TODO: If this is consistently undefined, implement an API-based membership check to verify bot membership before responding.
 
   const ctxId = isDM ? `dm:${message.user?.id}` : `${channel.id}`;
 
@@ -33,18 +35,21 @@ export async function execute(
     return;
   }
 
-  const isOwnDM = isDM && channel.id === myDMId;
+
   const hasKeyword = keywords.some((kw) =>
     content.toLowerCase().includes(kw.toLowerCase()),
   );
   const isMentioned = content.includes(`<@${botUser.username}>`);
 
   logger.info(
-    { ctxId, user: user.username, isMentioned, hasKeyword, content, isOwnDM },
+    { ctxId, user: user.username, isDM, isMember, isMentioned, hasKeyword, content },
     "Incoming message"
   );
 
-  if (isDM && !isOwnDM) return;
+  if (isDM && !isMember) {
+    logger.info({ ctxId, user: user.username, isDM, isMember }, "Ignoring DM: bot not a member or membership unknown");
+    return;
+  }
 
   if (!isDM && !hasKeyword && !isMentioned) return;
 


### PR DESCRIPTION
## Summary
The bot did not respond to most Direct Messages because the handler only allowed replies when the DM channel ID matched `botUser.custom_fields.last_chat_channel_id`. This effectively limited responses to a single DM channel.

This PR changes the DM gating to check whether the bot is a member of the DM channel via `channel.current_user_membership`. If the bot is a member, it proceeds; otherwise it ignores the DM. Non-DM behavior remains unchanged (reply only on mention or matching keyword). Logging is expanded for better visibility, and a conservative fallback is used when membership info is unavailable.

## Changes
- Replace single-channel DM gating with membership gating:
  - `isMember = Boolean(channel.current_user_membership)`
  - If `isDM && !isMember`, ignore; otherwise proceed
  - Do not use `botUser.custom_fields.last_chat_channel_id`
- Preserve rate-limiting context key: `ctxId = isDM ? \`dm:${message.user?.id}\` : \`${channel.id}\``
- Preserve non-DM gating on keywords/mentions
- Improve logging:
  - Include `isDM` and `isMember` in the log context
  - Log when a DM is ignored due to missing membership
- Add a TODO comment: if `current_user_membership` is consistently undefined in some environments, consider an API-based membership check and keep conservative behavior in the meantime

## Impact
- The bot now replies to DMs sent directly to it by any user (where the bot is a channel member)
- The bot does not respond to DMs it is not part of, preventing replies in other users' private conversations
- Non-DM behavior is unchanged
- Existing rate limiting and message fetching remain unchanged
- Logs provide clearer visibility (`isDM`, `isMember`, and ignored-DM reasons)

## Acceptance Criteria Mapping
- Replies to any DM sent to the bot: ✅
- No responses to other users' DMs: ✅ (bot only replies when it has membership)
- Non-DM channels unchanged (mention/keyword required): ✅
- Rate limiting and message retrieval unchanged: ✅
- Logs show `isDM`, `isMember`, and ignored-DM reasons: ✅

## Testing Notes
- Send a DM to the bot from multiple users: bot should reply in each case
- Ensure a DM between other users (if delivered via webhook) is ignored
- In non-DM channels, verify replies only occur on mention or configured keywords

## Files Changed
- `server/events/message-create/index.ts`

₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/fde08a90-c201-4f24-84f5-4e7298e0c3ab/task/b59910ca-5c1e-4ca4-83a7-cdaa46f5dd53))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved DM behavior: the bot now responds only in direct messages where it is a confirmed member; otherwise, it silently ignores the DM.
  - Reduces unintended replies in private conversations the bot isn’t part of, improving privacy and reducing noise.
  - All other message handling (mentions, keywords, rate limiting, responses) remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->